### PR TITLE
Fix for CWE-552: Files or Directories Accessible to External Parties

### DIFF
--- a/data/static/codefixes/accessLogDisclosureChallenge_2.ts
+++ b/data/static/codefixes/accessLogDisclosureChallenge_2.ts
@@ -11,8 +11,6 @@
   app.use('/encryptionkeys/:file', serveKeyFiles())
 
   /* /logs directory browsing */
-  app.use('/support/logs', serveIndexMiddleware, serveIndex('logs', { icons: true }))
-  app.use('/support/logs/:file', serveLogFiles())
 
   /* Swagger documentation for B2B v2 endpoints */
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in data/static/codefixes/accessLogDisclosureChallenge_2.ts.

It is CWE-552: Files or Directories Accessible to External Parties that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix removes the routes that allowed browsing and direct access to log files under /support/logs, preventing unauthorized users from viewing sensitive log data.<br>- Removed &quot;app.use(&#x27;/support/logs&#x27;, serveIndexMiddleware, serveIndex(&#x27;logs&#x27;, { icons: true }))&quot; to disable directory listing of logs.<br>    - Removed &quot;app.use(&#x27;/support/logs/:file&#x27;, serveLogFiles())&quot; to block direct access to individual log files.<br>    - These changes ensure that sensitive log files cannot be accessed or enumerated by unauthorized actors.

### 💡 Important Instructions
Verify that no internal functionality depends on accessing logs via these routes and consider implementing proper authentication if log access is still required.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/d78ba8ab-0474-4d52-a2b4-a419372eb240)

